### PR TITLE
Adding support for IComparisonOperators to U8String

### DIFF
--- a/Sources/U8String/U8String.Comparison.cs
+++ b/Sources/U8String/U8String.Comparison.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Numerics;
 
 using U8.Abstractions;
 using U8.Primitives;
@@ -8,7 +9,7 @@ using U8.Shared;
 namespace U8;
 
 #pragma warning disable RCS1003 // Add braces. Why: manual codegen tuning.
-public readonly partial struct U8String
+public readonly partial struct U8String : IComparisonOperators<U8String, U8String, bool>
 {
     /// <summary>
     /// Compares two <see cref="U8String"/> instances lexicographically.
@@ -365,4 +366,12 @@ public readonly partial struct U8String
     {
         return comparer.GetHashCode(value);
     }
+
+    public static bool operator >(U8String left, U8String right) => left.CompareTo(right) > 0;
+
+    public static bool operator >=(U8String left, U8String right) => left.CompareTo(right) >= 0;
+
+    public static bool operator <(U8String left, U8String right) => left.CompareTo(right) < 0;
+
+    public static bool operator <=(U8String left, U8String right) => left.CompareTo(right) <= 0;
 }

--- a/Sources/U8String/U8String.Comparison.cs
+++ b/Sources/U8String/U8String.Comparison.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Numerics;
 
 using U8.Abstractions;
 using U8.Primitives;
@@ -9,7 +8,7 @@ using U8.Shared;
 namespace U8;
 
 #pragma warning disable RCS1003 // Add braces. Why: manual codegen tuning.
-public readonly partial struct U8String : IComparisonOperators<U8String, U8String, bool>
+public readonly partial struct U8String
 {
     /// <summary>
     /// Compares two <see cref="U8String"/> instances lexicographically.
@@ -366,12 +365,4 @@ public readonly partial struct U8String : IComparisonOperators<U8String, U8Strin
     {
         return comparer.GetHashCode(value);
     }
-
-    public static bool operator >(U8String left, U8String right) => left.CompareTo(right) > 0;
-
-    public static bool operator >=(U8String left, U8String right) => left.CompareTo(right) >= 0;
-
-    public static bool operator <(U8String left, U8String right) => left.CompareTo(right) < 0;
-
-    public static bool operator <=(U8String left, U8String right) => left.CompareTo(right) <= 0;
 }

--- a/Sources/U8String/U8String.Operators.cs
+++ b/Sources/U8String/U8String.Operators.cs
@@ -1,9 +1,10 @@
 using System.Collections.Immutable;
+using System.Numerics;
 using System.Text;
 
 namespace U8;
 
-public readonly partial struct U8String
+public readonly partial struct U8String : IComparisonOperators<U8String, U8String, bool>
 {
     /// <inheritdoc cref="Concat(U8String, byte)"/>
     public static U8String operator +(U8String left, byte right) => Concat(left, right);
@@ -64,6 +65,11 @@ public readonly partial struct U8String
     public static bool operator !=(byte[]? left, U8String right) => !(left == right);
     public static bool operator !=(ImmutableArray<byte> left, U8String right) => !(left == right);
     public static bool operator !=(ReadOnlySpan<byte> left, U8String right) => !(left == right);
+
+    public static bool operator >(U8String left, U8String right) => left.CompareTo(right) > 0;
+    public static bool operator >=(U8String left, U8String right) => left.CompareTo(right) >= 0;
+    public static bool operator <(U8String left, U8String right) => left.CompareTo(right) < 0;
+    public static bool operator <=(U8String left, U8String right) => left.CompareTo(right) <= 0;
 
     /// <inheritdoc cref="Create(ReadOnlySpan{byte})"/>
     public static explicit operator U8String(ReadOnlySpan<byte> value) => new(value);


### PR DESCRIPTION
A very simple PR that adds the [`System.Numerics.IComparisonOperators`](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.icomparisonoperators-3?view=net-8.0) interface to the `U8String` type.